### PR TITLE
Use '>>' instead of '>'

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ## Installation 
 ### Ghost Server
 ```
-echo 'export PATH="~f103207425/.local/bin:$PATH"' > ~/.profile
+echo 'export PATH="~f103207425/.local/bin:$PATH"' >> ~/.profile
 source ~/.bashrc
 ```
 

--- a/assign_mapping.json
+++ b/assign_mapping.json
@@ -23,5 +23,10 @@
     "contest_id": 13,
     "contest_problem_id": "1091CP1+Assign3",
     "problem_id": 153
+  },
+  "ex3": {
+    "contest_id": 14,
+    "contest_problem_id": "1091CP1+Exercise3",
+    "problem_id": 154
   }
 }


### PR DESCRIPTION
`echo 'export PATH="~f103207425/.local/bin:$PATH"' > ~/.profile` will overwrite the `.profile`.
You have to use `>>` instead of `>` in this command.